### PR TITLE
Version : getting ready for Elasticsearch RC1

### DIFF
--- a/src/kopf/elastic/elastic_client.js
+++ b/src/kopf/elastic/elastic_client.js
@@ -225,7 +225,7 @@ function ElasticClient(host,username,password) {
 			}),
 			$.ajax({ 
 				type: 'GET', 
-				url: host+"/_cluster/nodes/stats?all=true", 
+				url: host+"/_nodes/stats/_all",     
 				dataType: 'json', 
 				data: {}, 
 				beforeSend: function(xhr) { 
@@ -283,7 +283,7 @@ function ElasticClient(host,username,password) {
 			}),
 			$.ajax({ 
 				type: 'GET', 
-				url: host+"/_cluster/nodes/stats?all=true", 
+				url: host+"/_nodes/stats/_all", 
 				dataType: 'json', 
 				data: {},
 				beforeSend: function(xhr) { 


### PR DESCRIPTION
Elasticsearch 1.0.0.RC1 is out. 
Some API calls have been deprecated or removed. 

This call is no more:

```
GET /_cluster/nodes/stats?all=true
```

Looks like the new way is:

```
GET /_nodes/stats/_all
``

Do you want to create a 
```
