### PR TITLE
Feature (Snapshots/Repositories) : added screen for repository creation and deletion

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,6 +67,7 @@ module.exports = function(grunt) {
 					'src/kopf/controllers/navbar.js',
 					'src/kopf/controllers/rest.js',
 					'src/kopf/controllers/percolator.js',
+					'src/kopf/controllers/repository.js',
 					'src/kopf/controllers/confirm_dialog.js',
 					'src/kopf/controllers/warmup.js',
 					// SERVICES
@@ -91,7 +92,8 @@ module.exports = function(grunt) {
 					'src/kopf/css/json_tree.css',
 					'src/kopf/css/navbar.css',
 					'src/kopf/css/rest_client.css',
-					'src/kopf/css/warmup.css'
+					'src/kopf/css/warmup.css',
+					'src/kopf/css/repository.css'
 				],
 				dest: 'dist/kopf.css'
 			},

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
 					<div class="tab-pane" id="analysis" ng-include src="'partials/analysis.html'"></div>
 					<div class="tab-pane" id="percolator" ng-include src="'partials/percolator.html'"></div>
 					<div class="tab-pane" id="warmup" ng-include src="'partials/warmup.html'"></div>
+					<div class="tab-pane" id="repository" ng-include src="'partials/repository.html'"></div>
 				</div>
 			</div>
 			<!-- modals used through the app -->

--- a/partials/nav_bar.html
+++ b/partials/nav_bar.html
@@ -67,6 +67,9 @@
 				<li class="" id="warmup_option" ng-click="selectTab('loadWarmupEvent')">
 					<a href="#warmup" data-toggle="tab" class=""><i class="icon-fire"></i> warmup</a>
 				</li>
+				<li class="" id="repository_option" ng-click="selectTab('loadRepositoryEvent')">
+					<a href="#repository" data-toggle="tab" class=""><i class="icon-suitcase"></i> repository</a>
+				</li>				
 			</ul>
 			<ul class="nav navbar-nav pull-right">
 				<li class="navbar-host-input">

--- a/partials/repository.html
+++ b/partials/repository.html
@@ -1,0 +1,87 @@
+<div ng-controller="RepositoryController" ng-show="hasConnection()">
+	<h2>repositories</h2>
+	<div class="content-panel">
+		<div class="panel-group" id="#percolatorAccordion">
+			<div class="panel panel-default">
+				<div class="panel-heading">
+					<h4 class="panel-title">
+						<a data-toggle="collapse" data-parent="#percolatorAccordion" href="#newRepository">
+							create new repository
+						</a>
+					</h4>
+				</div>
+				<div id="newRepository" class="panel-collapse collapse">
+					<div class="panel-body">
+						<div class="row">
+							<div class="col-lg-4">
+								<form role="form">
+								  <div class="form-group">
+								    <label class="form-label">repository name</label>
+									<input ng-model="new_repo.name" class="form-control input-sm" placeholder="repository name">
+								  </div>
+								  <div class="form-group">
+								    <label class="form-label">type</label>
+									<input ng-model="new_repo.type" class="form-control input-sm" placeholder="repository type (fs, hdfs, s3)">
+								  </div>
+								  <button type="submit" class="btn btn-primary rest-client-execute input-sm pull-right" ng-click="createRepository()">
+									  <i class="icon-file-alt"></i> create
+								  </button>
+								</form>
+							</div>
+							<div class="col-lg-8">
+								<div class="form-group">
+									<label class="form-label">settings</label>
+									<div id="repository-settings-editor" class="repository-settings-editor"></div>
+								</div>
+								<div class="row">
+									<div class="col-lg-12">
+										<span class="validation-error">{{validation_error}}</span>
+										<button type="submit" class="btn btn-default input-sm pull-right" ng-click="editor.format()">
+											<i class="icon-align-left"></i> format settings
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="panel panel-default">
+				<div class="panel-heading">
+					<h4 class="panel-title">
+						<a data-toggle="collapse" data-parent="#repositoryAccordion" href="#repositoryList">
+							repositories
+						</a>
+					</h4>
+				</div>
+				<div id="repositoryList" class="panel-collapse collapse in">
+					<div class="panel-body">
+						<div class="table-panel">
+							<div class="row">
+								<div class="col-lg-12">
+									<table class="table table-bordered table-striped">
+										<tr class="header-row">
+											<td>name</td>
+											<td>type</td>
+											<td>settings</td>
+										</tr>
+										<tr ng-repeat="(key, value) in repositories" class="content-row">
+											<td>{{key}}</td>
+											<td>{{value.type}}</td>
+											<td>{{value.settings}}
+												<a data-toggle="modal" href="#confirm_dialog" 
+												class="remove-icon" data-backdrop="static" data-keyboard="false">
+													<i class="icon-remove remove-icon" ng-click="deleteRepository(key, value)"></i>
+												</a>
+											</td>
+										</tr>
+									</table>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/kopf/controllers/repository.js
+++ b/src/kopf/controllers/repository.js
@@ -1,0 +1,99 @@
+function RepositoryController($scope, $location, $timeout, ConfirmDialogService, AlertService) {
+
+	$scope.alert_service = AlertService;
+	$scope.dialog_service = ConfirmDialogService;
+	
+	$scope.editor = new AceEditor('repository-settings-editor');
+	$scope.repositories = [];
+	
+    $scope.$on('loadRepositoryEvent', function() {
+		$scope.loadRepositories();
+    });
+	
+	$scope.deleteRepository=function(name, value){
+		$scope.dialog_service.open(
+			"are you sure you want to delete repository " + name + "?",
+			value,
+			"Delete",
+			function() {
+				$scope.client.deleteRepository(name,
+					function(response) {
+						$scope.alert_service.success("Repository successfully deleted", response);
+						$scope.loadRepositories();
+					},
+					function(error) {
+						$scope.updateModel(function() {
+							$scope.alert_service.error("Error while deleting repositor", error);
+						});
+					}
+				);
+			}
+		);
+	}
+
+	/*
+		createRepository
+
+		example:
+			POST /_snapshot/my_repository/
+			{
+				"type": "fs",
+				"settings": {
+					"location": "/mount/backups/my_backup",
+					"compress": true
+				}
+			}
+
+		settings field from editor should contain:
+		{
+    		"location": "/mount/backups/my_backup",
+    		"compress": true
+		}
+	*/
+	$scope.createRepository=function(){
+		$scope.new_repo.settings = $scope.editor.format();
+		if ($scope.editor.error == null) {
+			var body = {
+				type: $scope.new_repo.type,
+				settings: JSON.parse($scope.new_repo.settings)
+			}
+
+			$scope.client.createRepository($scope.new_repo.name, JSON.stringify(body), 
+				function(response) {
+					$scope.alert_service.success("Repository created");
+					$scope.loadRepositories();
+				},
+				function(error) {
+					$scope.updateModel(function() {
+						$scope.alert_service.error("Error while creating repository", error);
+					});
+				}
+			);
+			
+		}		
+	}
+
+	$scope.loadRepositories=function() {
+		try {			
+			$scope.client.getRepositories(
+				function(response) {
+					$scope.updateModel(function() {
+						$scope.repositories = response;
+					});
+				},
+				function(error) {
+					if (!(error['responseJSON'] != null )) {
+						$scope.updateModel(function() {
+							$scope.alert_service.error("Error while reading repositories", error);
+						});
+					}
+				}
+			)
+		} catch (error) {
+			$scope.alert_service.error("Failed to load repositories");
+			return;
+		}
+
+	};
+
+}

--- a/src/kopf/css/repository.css
+++ b/src/kopf/css/repository.css
@@ -1,0 +1,8 @@
+.repository-settings-editor {
+	height: 400px;
+	width: auto;
+	border: 1px solid #ccc;
+	border-radius: 3px 3px 3px 3px;
+	text-align: left;
+	width: 100%;
+}

--- a/src/kopf/elastic/elastic_client.js
+++ b/src/kopf/elastic/elastic_client.js
@@ -146,6 +146,22 @@ function ElasticClient(host,username,password) {
 		this.syncRequest('PUT', "/_percolator/" + index + "/" + id, body, callback_success, callback_error);
 	};
 	
+	this.getRepositories=function(callback_success, callback_error) {
+		this.syncRequest('GET', "/_snapshot/_all", {}, callback_success, callback_error);	
+	};
+
+	this.createRepository=function(repository, body, callback_success, callback_error) {
+		this.syncRequest('POST', "/_snapshot/" + repository, body, callback_success, callback_error);
+	};
+
+	this.deleteRepository=function(repository, callback_success, callback_error) {
+		this.syncRequest('DELETE', "/_snapshot/" + repository, {}, callback_success, callback_error);
+	};
+
+	this.getSnapshots=function(repository, callback_success, callback_error){
+		this.synchRequest('GET', "/_snapshot/" + repository + "/_all", callback_success, callback_error);
+	};
+
 	this.syncRequest=function(method, path, data, callback_success, callback_error) {
 		var url = this.host + path;
 		this.executeRequest(method,url,this.username,this.password, data, callback_success, callback_error);
@@ -224,7 +240,7 @@ function ElasticClient(host,username,password) {
 			}),
 			$.ajax({ 
 				type: 'GET', 
-				url: host+"/_cluster/nodes/stats?all=true", 
+				url: host+"/_nodes/stats?all=true",
 				dataType: 'json', 
 				data: {}, 
 				beforeSend: function(xhr) { 
@@ -282,7 +298,7 @@ function ElasticClient(host,username,password) {
 			}),
 			$.ajax({ 
 				type: 'GET', 
-				url: host+"/_cluster/nodes/stats?all=true", 
+				url: host+"/_nodes/stats?all=true",
 				dataType: 'json', 
 				data: {},
 				beforeSend: function(xhr) { 


### PR DESCRIPTION
Feature (Snapshots/Repositories) : added screen for repository creation and deletion

Added screen to manage add/delete of repositories. 
This is the first step to complete snapshot/repo CRUD. 

Please review menu icon (briefcase? and let me know if you want something different). 
Please review code and provide feedback. 

Next Steps:
- add individual snapshot control per repo (second set of create/table controls on screen, with filter by repo?)
- dropdown for type instead of free form (I think fs is the only for now but s3 and hdfs is coming soon) 
- unit tests?

[ES 1.0.0 Doco for Repositories/Snapshots](http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html)
