### PR TITLE
Fix node status for Elasticsearch 1.0.0.RC1

### DIFF
--- a/dist/kopf.js
+++ b/dist/kopf.js
@@ -415,7 +415,7 @@ function ElasticClient(host,username,password) {
 			}),
 			$.ajax({ 
 				type: 'GET', 
-				url: host+"/_cluster/nodes/stats?all=true", 
+				url: host+"/_cluster/state/nodes",
 				dataType: 'json', 
 				data: {}, 
 				beforeSend: function(xhr) { 
@@ -473,7 +473,7 @@ function ElasticClient(host,username,password) {
 			}),
 			$.ajax({ 
 				type: 'GET', 
-				url: host+"/_cluster/nodes/stats?all=true", 
+				url: host+"/_cluster/state/nodes",
 				dataType: 'json', 
 				data: {},
 				beforeSend: function(xhr) { 

--- a/src/kopf/elastic/elastic_client.js
+++ b/src/kopf/elastic/elastic_client.js
@@ -224,7 +224,7 @@ function ElasticClient(host,username,password) {
 			}),
 			$.ajax({ 
 				type: 'GET', 
-				url: host+"/_cluster/nodes/stats?all=true", 
+				url: host+"/_cluster/state/nodes",
 				dataType: 'json', 
 				data: {}, 
 				beforeSend: function(xhr) { 


### PR DESCRIPTION
fixing the node stats on 1.0.0.RC1 due to:
http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/_stats_and_info_apis.html
