### PR TITLE
Chore : create AceEditor service

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,7 @@ module.exports = function(grunt) {
 					// SERVICES
 					'src/kopf/services/alerts.js',
 					'src/kopf/services/settings.js',
+					'src/kopf/services/aceeditor.js',
 					// MODELS
 					'src/kopf/models/ace_editor.js',
 					'src/kopf/models/gist.js',

--- a/src/kopf/controllers/aliases.js
+++ b/src/kopf/controllers/aliases.js
@@ -1,12 +1,17 @@
-function AliasesController($scope, $location, $timeout, AlertService) {
+function AliasesController($scope, $location, $timeout, AlertService, AceEditorService) {
 	$scope.aliases = null;
 	$scope.new_index = {};
 	$scope.pagination= new AliasesPagination(1, []);
-	
-	$scope.editor = new AceEditor('alias-filter-editor');
+	$scope.editor = undefined;
 	
 	$scope.viewDetails=function(alias) {
 		$scope.details = alias;
+	};
+
+	$scope.initEditor=function(){
+		if(!angular.isDefined($scope.editor)){
+			$scope.editor = AceEditorService.init('alias-filter-editor');
+		}
 	};
 
 	$scope.addAlias=function() {
@@ -15,14 +20,14 @@ function AliasesController($scope, $location, $timeout, AlertService) {
 			try {
 				$scope.new_alias.validate();
 				// if alias already exists, check if its already associated with index
-				if (isDefined($scope.aliases.info[$scope.new_alias.alias])) { 
+				if (isDefined($scope.aliases.info[$scope.new_alias.alias])) {
 					var aliases = $scope.aliases.info[$scope.new_alias.alias];
 					$.each(aliases,function(i, alias) {
 						if (alias.index === $scope.new_alias.index) {
 							throw "Alias is already associated with this index";
-						} 
+						}
 					});
-				} else { 
+				} else {
 					$scope.aliases.info[$scope.new_alias.alias] = [];
 				}
 				$scope.aliases.info[$scope.new_alias.alias].push($scope.new_alias);
@@ -60,9 +65,9 @@ function AliasesController($scope, $location, $timeout, AlertService) {
 			var aliases = $scope.aliases.info[alias_name];
 			aliases.forEach(function(alias) {
 				// if alias didnt exist, just add it
-				if (!isDefined($scope.originalAliases.info[alias_name])) { 
+				if (!isDefined($scope.originalAliases.info[alias_name])) {
 					adds.push(alias);
-				} else { 
+				} else {
 					var originalAliases = $scope.originalAliases.info[alias_name];
 					var addAlias = true;
 					for (var i = 0; i < originalAliases.length; i++) {
@@ -74,7 +79,7 @@ function AliasesController($scope, $location, $timeout, AlertService) {
 					if (addAlias) {
 						adds.push(alias);
 					}
-				} 
+				}
 			});
 		});
 		Object.keys($scope.originalAliases.info).forEach(function(alias_name) {
@@ -97,7 +102,7 @@ function AliasesController($scope, $location, $timeout, AlertService) {
 				}
 			});
 		});
-		$scope.client.updateAliases(adds,deletes, 
+		$scope.client.updateAliases(adds,deletes,
 			function(response) {
 				$scope.updateModel(function() {
 					AlertService.success("Aliases were successfully updated",response);
@@ -124,7 +129,7 @@ function AliasesController($scope, $location, $timeout, AlertService) {
 			},
 			function(error) {
 				$scope.updateModel(function() {
-					AlertService.error("Error while fetching aliases",error);		
+					AlertService.error("Error while fetching aliases",error);
 				});
 			}
 		);
@@ -132,6 +137,7 @@ function AliasesController($scope, $location, $timeout, AlertService) {
 	
     $scope.$on('loadAliasesEvent', function() {
 		$scope.loadAliases();
+		$scope.initEditor();
     });
 
 }

--- a/src/kopf/controllers/percolator.js
+++ b/src/kopf/controllers/percolator.js
@@ -1,8 +1,7 @@
-function PercolatorController($scope, $location, $timeout, ConfirmDialogService, AlertService) {
+function PercolatorController($scope, $location, $timeout, ConfirmDialogService, AlertService, AceEditorService) {
 	$scope.dialog_service = ConfirmDialogService;
 	
-	$scope.editor = new AceEditor('percolator-query-editor');
-		
+	$scope.editor = undefined;
 	$scope.total = 0;
 	$scope.queries = [];
 	$scope.page = 1;
@@ -15,8 +14,15 @@ function PercolatorController($scope, $location, $timeout, ConfirmDialogService,
 	
 	$scope.$on('loadPercolatorEvent', function() {
 		$scope.indices = $scope.cluster.indices;
+		$scope.initEditor();
     });
 	
+	$scope.initEditor=function(){
+		if(!angular.isDefined($scope.editor)){
+			$scope.editor = AceEditorService.init('percolator-query-editor');
+		}
+	};
+
 	$scope.previousPage=function() {
 		$scope.page -= 1;
 		$scope.loadPercolatorQueries();
@@ -68,7 +74,7 @@ function PercolatorController($scope, $location, $timeout, ConfirmDialogService,
 				$scope.client.deletePercolatorQuery(query.index, query.id,
 					function(response) {
 						var refreshIndex = $scope.client.is1() ? query.index : '_percolator';
-						$scope.client.refreshIndex(refreshIndex, 
+						$scope.client.refreshIndex(refreshIndex,
 							function(response) {
 								$scope.updateModel(function() {
 									AlertService.success("Query successfully deleted", response);
@@ -98,7 +104,7 @@ function PercolatorController($scope, $location, $timeout, ConfirmDialogService,
 			$scope.client.createPercolatorQuery($scope.new_query.index.name, $scope.new_query.id, $scope.new_query.source,
 				function(response) {
 					var refreshIndex = $scope.client.is1() ? $scope.new_query.index.name : '_percolator';
-					$scope.client.refreshIndex(refreshIndex, 
+					$scope.client.refreshIndex(refreshIndex,
 						function(response) {
 							$scope.updateModel(function() {
 								AlertService.success("Percolator Query successfully created", response);
@@ -151,7 +157,7 @@ function PercolatorController($scope, $location, $timeout, ConfirmDialogService,
 						});
 					}
 				}
-			);				
+			);
 		} catch (error) {
 			AlertService.error("Filter is not a valid JSON");
 			return;

--- a/src/kopf/controllers/repository.js
+++ b/src/kopf/controllers/repository.js
@@ -1,4 +1,4 @@
-function RepositoryController($q, $scope, $location, $timeout, ConfirmDialogService, AlertService) {
+function RepositoryController($q, $scope, $location, $timeout, ConfirmDialogService, AlertService, AceEditorService) {
 
 	$scope.dialog_service = ConfirmDialogService;
 	$scope.repositories = [];
@@ -18,7 +18,7 @@ function RepositoryController($q, $scope, $location, $timeout, ConfirmDialogServ
 	
 	$scope.initEditor=function(){
 		if(!angular.isDefined($scope.editor)){
-			$scope.editor = new AceEditor('repository-settings-editor');
+			$scope.editor = AceEditorService.init('repository-settings-editor');
 		}
 	};
 

--- a/src/kopf/controllers/rest.js
+++ b/src/kopf/controllers/rest.js
@@ -1,4 +1,4 @@
-function RestController($scope, $location, $timeout, AlertService) {
+function RestController($scope, $location, $timeout, AlertService, AceEditorService) {
 	
 	$scope.request = new Request($scope.connection.host + "/_search","GET","{}");
 	$scope.validation_error = null;
@@ -13,16 +13,19 @@ function RestController($scope, $location, $timeout, AlertService) {
 			} catch (error) {
 				localStorage.kopf_request_history = null;
 			}
-		} 
+		}
 		return history;
 	};
 	
 	$scope.history = $scope.loadHistory();
 	$scope.history_request = null;
-		
-	$scope.editor = new AceEditor('rest-client-editor');
+
+	if(!angular.isDefined($scope.editor)){
+		$scope.editor = AceEditorService.init('rest-client-editor');
+	}
+
 	$scope.editor.setValue($scope.request.body);
-	
+
 	$scope.loadFromHistory=function(history_request) {
 		$scope.request.url = history_request.url;
 		$scope.request.body = history_request.body;
@@ -44,7 +47,7 @@ function RestController($scope, $location, $timeout, AlertService) {
 			if ($scope.history.length > 30) {
 				$scope.history.length = 30;
 			}
-			localStorage.kopf_request_history = JSON.stringify($scope.history);			
+			localStorage.kopf_request_history = JSON.stringify($scope.history);
 		}
 	};
 
@@ -75,7 +78,7 @@ function RestController($scope, $location, $timeout, AlertService) {
 						if (error.status !== 0) {
 							AlertService.error("Request was not successful: " + error.statusText);
 						} else {
-							AlertService.error($scope.request.url + " is unreachable");	
+							AlertService.error($scope.request.url + " is unreachable");
 						}
 					});
 					try {

--- a/src/kopf/controllers/warmup.js
+++ b/src/kopf/controllers/warmup.js
@@ -1,11 +1,6 @@
-function WarmupController($scope, $location, $timeout, ConfirmDialogService, AlertService) {
+function WarmupController($scope, $location, $timeout, ConfirmDialogService, AlertService, AceEditorService) {
 	$scope.dialog_service = ConfirmDialogService;
-	
-	$scope.editor = ace.edit("warmup-query-editor");
-	$scope.editor.setFontSize("10px");
-	$scope.editor.setTheme("ace/theme/kopf");
-	$scope.editor.getSession().setMode("ace/mode/json");
-
+	$scope.editor = undefined;
 	$scope.indices = [];
 	$scope.warmers = {};
 	$scope.index = null;
@@ -19,8 +14,15 @@ function WarmupController($scope, $location, $timeout, ConfirmDialogService, Ale
 	
     $scope.$on('loadWarmupEvent', function() {
 		$scope.loadIndices();
+		$scope.initEditor();
     });
 	
+	$scope.initEditor=function(){
+		if(!angular.isDefined($scope.editor)){
+			$scope.editor = AceEditorService.init('warmup-query-editor');
+		}
+	};
+
 	$scope.totalWarmers=function() {
 		return Object.keys($scope.warmers).length;
 	};
@@ -35,12 +37,12 @@ function WarmupController($scope, $location, $timeout, ConfirmDialogService, Ale
 			$scope.client.registerWarmupQuery($scope.new_index.name, $scope.new_types, $scope.new_warmer_id, $scope.new_source,
 				function(response) {
 					$scope.updateModel(function() {
-						AlertService.success("Warmup query successfully registered", response);						
+						AlertService.success("Warmup query successfully registered", response);
 					});
 				},
 				function(error) {
 					$scope.updateModel(function() {
-						AlertService.error("Request did not return a valid JSON", error);						
+						AlertService.error("Request did not return a valid JSON", error);
 					});
 				}
 			);

--- a/src/kopf/services/aceeditor.js
+++ b/src/kopf/services/aceeditor.js
@@ -1,0 +1,9 @@
+
+kopf.factory('AceEditorService', function() {
+
+	this.init=function(name) {
+		return new AceEditor(name);
+	};
+
+	return this;
+});

--- a/tests/jasmine/repository.tests.js
+++ b/tests/jasmine/repository.tests.js
@@ -17,9 +17,11 @@ describe('RepositoryController', function(){
         this.ConfirmDialogService = $injector.get('ConfirmDialogService');
         var AlertService = $injector.get('AlertService');
         this.AlertService = AlertService;
+        var AceEditorService = $injector.get('AceEditorService');
+        this.AceEditorService = AceEditorService;
 
         this.createController = function() {
-            return $controller('RepositoryController', {$scope: this.scope}, $location, $timeout, this.ConfirmDialogService, AlertService);
+            return $controller('RepositoryController', {$scope: this.scope}, $location, $timeout, this.ConfirmDialogService, AlertService, AceEditorService);
         };
 
         this._controller = this.createController();
@@ -39,10 +41,13 @@ describe('RepositoryController', function(){
 
     it('on : makes calls reload and initEditor', function() {
         spyOn(this.scope, 'reload').andReturn(true);
-        spyOn(this.scope, 'initEditor').andReturn(true);
+        spyOn(this.scope, 'initEditor').andCallThrough();
+        spyOn(this.AceEditorService, 'init').andReturn("fakeaceeditor");
         this.scope.$emit("loadRepositoryEvent");
         expect(this.scope.reload).toHaveBeenCalled();
         expect(this.scope.initEditor).toHaveBeenCalled();
+        expect(this.AceEditorService.init).toHaveBeenCalledWith('repository-settings-editor');
+        expect(this.scope.editor).toEqual("fakeaceeditor");
     });
 
     it('loadIndices : assigns a value to indices from cluster.indices', function() {


### PR DESCRIPTION
Chore : create AceEditor service

1 - I moved ace editor instantiation to a factory service. This will make unit testing simpler against these controllers. I think in the long run we want to use a [directive for the AceEditor](https://github.com/angular-ui/ui-ace). 

2 - cleared a bunch of trailing white space from files I was in

Tests Clear:

```
mconlin-mbp:elasticsearch-kopf mconlin$ grunt test
Running "karma:unit" (karma) task
........ snip.....
PhantomJS 1.9.7 (Mac OS X): Executed 24 of 24 SUCCESS (0.169 secs / 0.05 secs)
```
