### PR TITLE
css to make hot_threads readable

### DIFF
--- a/dist/kopf.css
+++ b/dist/kopf.css
@@ -168,7 +168,8 @@ a.setting-info:hover {
 	text-align: right;
 }
 .cluster-health-content {
-	font-family: inherit;
+	font-family: monospace;
+	white-space: pre;
 }
 
 .cluster-health-form-group {

--- a/src/kopf/css/cluster_health.css
+++ b/src/kopf/css/cluster_health.css
@@ -2,7 +2,8 @@
 	text-align: right;
 }
 .cluster-health-content {
-	font-family: inherit;
+	font-family: monospace;
+	white-space: pre;
 }
 
 .cluster-health-form-group {


### PR DESCRIPTION
I debated on using monospace or leaving it inherited. Ultimately I think the leading space padding helps readability.
