### PR TITLE
adding basic auth support to rest tab

### DIFF
--- a/dist/kopf.js
+++ b/dist/kopf.js
@@ -2356,11 +2356,14 @@ function RestController($scope, $location, $timeout, AlertService, AceEditorServ
 		$scope.request.body = $scope.editor.format();
 		$('#rest-client-response').html('');
 		if (notEmpty($scope.request.url)) {
-			// TODO: deal with basic auth here
+			var a = document.createElement('a');
+			a.href = $scope.request.url;
+			var username = a.username || null;
+			var password = a.password || null;
 			if ($scope.request.method == 'GET' && '{}' !== $scope.request.body) {
 				AlertService.info("You are executing a GET request with body content. Maybe you meant to use POST or PUT?");
 			}
-			$scope.client.executeRequest($scope.request.method,$scope.request.url,null,null,$scope.request.body,
+			$scope.client.executeRequest($scope.request.method,$scope.request.url,username,password,$scope.request.body,
 				function(response) {
 					var content = response;
 					try {

--- a/src/kopf/controllers/rest.js
+++ b/src/kopf/controllers/rest.js
@@ -55,11 +55,14 @@ function RestController($scope, $location, $timeout, AlertService, AceEditorServ
 		$scope.request.body = $scope.editor.format();
 		$('#rest-client-response').html('');
 		if (notEmpty($scope.request.url)) {
-			// TODO: deal with basic auth here
+			var a = document.createElement('a');
+			a.href = $scope.request.url;
+			var username = a.username || null;
+			var password = a.password || null;
 			if ($scope.request.method == 'GET' && '{}' !== $scope.request.body) {
 				AlertService.info("You are executing a GET request with body content. Maybe you meant to use POST or PUT?");
 			}
-			$scope.client.executeRequest($scope.request.method,$scope.request.url,null,null,$scope.request.body,
+			$scope.client.executeRequest($scope.request.method,$scope.request.url,username,password,$scope.request.body,
 				function(response) {
 					var content = response;
 					try {


### PR DESCRIPTION
I noticed the REST tab doesn't support basic auth yet. With this change you can enter `http://user:pwd@localhost:9200/_search` in the REST request panel and it will add the Authorization header to the request.

I should note that this doesn't populate the REST request panel with the URL from the location query parameter. You can still manually change the URL to have the basic auth credentials then it works.

I ran `npm install` and `grunt build` to lint, test, and build it.
