### PR TITLE
fix rename regexp typo in restore_snapshot.html

### DIFF
--- a/partials/repositories/restore_snapshot.html
+++ b/partials/repositories/restore_snapshot.html
@@ -3,7 +3,7 @@
 	    "indices": "index_1,index_2",
 	    "ignore_unavailable": "true",
 	    "include_global_state": false,
-	    "rename_pattern": "index_(.)+",
+	    "rename_pattern": "index_(.+)",
 	    "rename_replacement": "restored_index_$1"
 	}'
 -->
@@ -28,7 +28,7 @@
 	<div class="row">
 		<div class="form-group col-lg-6 col-md-12 col-sm-6">
 			<label class="form-label">rename pattern</label>
-			<input ng-model="restore_snap.rename_pattern" class="form-control input-sm" placeholder="index_(.)+">
+			<input ng-model="restore_snap.rename_pattern" class="form-control input-sm" placeholder="index_(.+)">
 		</div>
 		<div class="form-group col-lg-6 col-md-12 col-sm-6">
 			<label class="form-label">rename replacement</label>


### PR DESCRIPTION
`index_(.)+`
should be
`index_(.+)`

http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-snapshots.html#_restore

https://github.com/elasticsearch/elasticsearch/commit/02ebe337583ad52a7b334b641f6602b143e8a662
