### PR TITLE
Add dataType to version request

### DIFF
--- a/src/kopf/elastic/elastic_client.js
+++ b/src/kopf/elastic/elastic_client.js
@@ -12,6 +12,7 @@ function ElasticClient(connection, http_service, q) {
 	var fetch_version = $.ajax({
 		type: 'GET',
 		url: connection.host + "/",
+		dataType: 'json',
 		beforeSend: function(xhr) {
 			if (isDefined(auth)) {
 				xhr.setRequestHeader("Authorization", auth);


### PR DESCRIPTION
jQuery fails to automatically detect the data type of the version
request with old versions of Firefox (20.0). Specifying the data
type explicitly fixes this problem.
