### PR TITLE
Fix 404 error of theme file (due to AngularJS not being loaded yet).

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link href="./font-awesome/css/font-awesome.css" rel="stylesheet">
     <link href="dist/lib.css" rel="stylesheet">
     <link href="dist/kopf.css" rel="stylesheet">
-    <link href="dist/{{getTheme()}}_style.css" rel="stylesheet">
+    <link ng-href="dist/{{getTheme()}}_style.css" rel="stylesheet">
     <script src="dist/lib.js" type="text/javascript" charset="utf-8"></script>
     <script src="dist/kopf.js" type="text/javascript" charset="utf-8"></script>
   </head>


### PR DESCRIPTION
This fixes a 404 error that happens when the application is first loaded and
the browser tries to fetch the file "/dist/{{getTheme()}}_style.css" without
interpolating the `getTheme()` function, since AngularJS is not loaded yet.
