### PR TITLE
rest-client-editor height unit from px to vh

### DIFF
--- a/partials/rest_client.html
+++ b/partials/rest_client.html
@@ -40,7 +40,7 @@
 								</span>
 							</div>
 							<div class="content-panel">
-								<div id="rest-client-editor" class="kopf-ace-editor" style="height: 580px"></div>
+								<div id="rest-client-editor" class="kopf-ace-editor" style="height:520px; height:70vh;"></div>
 							</div>
 							<div class="content-panel action-buttons">
 								<span class="danger-action">{{editor.error}}</span>


### PR DESCRIPTION
The request form submit buttons are below the fold requiring frequent scrolling. The height is now 70% of the viewport with a pixel fallback reduced from 580px to 520px.
http://caniuse.com/#feat=viewport-units
