### PR TITLE
[DUPLICATE] 'Rest' tab improvement: submit request on ENTER.

### DIFF
--- a/partials/rest_client.html
+++ b/partials/rest_client.html
@@ -9,52 +9,53 @@
 						</h4>
 					</div>
 					<div id="restRequest" class="panel-collapse collapse in">
-						<div class="panel-body">
-							<div>
-								<span class="history-icon">
-									<a title="show/hide request history" data-toggle="collapse" data-parent="#restAccordion" target="_self" href="#restHistory"><i class="fa fa-history"></i></a>
-								</span>
-								<span>
-									<select ng-model="request.method" class="form-control input-sm rest-client-request-method">
-										<option value="GET" selected="selected">GET</option>
-										<option value="PUT">PUT</option>
-										<option value="POST">POST</option>
-										<option value="DELETE">DELETE</option>
-									</select>
-									<span class="rest-client-request-url">
-										<input type="text" ng-model="request.path" class="form-control input-sm" placeholder="path relative to connected node (e.g.: /index/type/_search)">
+						<form>
+							<div class="panel-body">
+								<div>
+									<span class="history-icon">
+										<a title="show/hide request history" data-toggle="collapse" data-parent="#restAccordion" target="_self" href="#restHistory"><i class="fa fa-history"></i></a>
 									</span>
-									<div id="restHistory" class="panel-collapse collapse" style="margin-right: 30px">
-										<a data-toggle="collapse" data-parent="#restAccordion" target="_self" href="#restHistory">
-											<span>
-												<table class="table table-striped table-condensed" style="width: 100%; margin-bottom: 0px;">
-													<tr ng-repeat="h in history" ng-click="loadFromHistory(h)" title="{{h.body}}" class="normal-action">
-														<td style="width: 75px">{{h.timestamp}}</td>
-														<td>{{h.path}}</td>
-														<td style="width: 75px">{{h.method}}</td>
-													</tr>
-												</table>
-											</span>
-										</a>
-									</div>
-								</span>
+									<span>
+										<select ng-model="request.method" class="form-control input-sm rest-client-request-method">
+											<option value="GET" selected="selected">GET</option>
+											<option value="PUT">PUT</option>
+											<option value="POST">POST</option>
+											<option value="DELETE">DELETE</option>
+										</select>
+										<span class="rest-client-request-url">
+											<input type="text" ng-model="request.path" class="form-control input-sm" placeholder="path relative to connected node (e.g.: /index/type/_search)">
+										</span>
+										<div id="restHistory" class="panel-collapse collapse" style="margin-right: 30px">
+											<a data-toggle="collapse" data-parent="#restAccordion" target="_self" href="#restHistory">
+												<span>
+													<table class="table table-striped table-condensed" style="width: 100%; margin-bottom: 0px;">
+														<tr ng-repeat="h in history" ng-click="loadFromHistory(h)" title="{{h.body}}" class="normal-action">
+															<td style="width: 75px">{{h.timestamp}}</td>
+															<td>{{h.path}}</td>
+															<td style="width: 75px">{{h.method}}</td>
+														</tr>
+													</table>
+												</span>
+											</a>
+										</div>
+									</span>
+								</div>
+								<div class="content-panel">
+									<div id="rest-client-editor" class="kopf-ace-editor" style="height: 580px"></div>
+								</div>
+								<div class="content-panel action-buttons">
+									<span class="danger-action">{{editor.error}}</span>
+									<button type="button" class="btn btn-default input-sm" ng-click="editor.format()">
+										<i class="fa fa-align-left"></i> format
+									</button>
+									<button type="submit" class="btn btn-primary input-sm" ng-click="sendRequest()">
+										<i class="fa fa-bolt"></i> send
+									</button>
+								</div>
 							</div>
-							<div class="content-panel">
-								<div id="rest-client-editor" class="kopf-ace-editor" style="height: 580px"></div>
-							</div>
-							<div class="content-panel action-buttons">
-								<span class="danger-action">{{editor.error}}</span>
-								<button type="submit" class="btn btn-default input-sm" ng-click="editor.format()">
-									<i class="fa fa-align-left"></i> format
-								</button>
-								<button type="submit" class="btn btn-primary input-sm" ng-click="sendRequest()">
-									<i class="fa fa-bolt"></i> send
-								</button>
-							</div>
-						</div>
-						
+						</form>
 					</div>
-					
+
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
In the current version, in the **rest** tab, the user has click on the "send" button to submit a request. Also, depending on your screen size, the "send" button might not even be above the fold, so you would also have to scroll down to find it, and that's for each and every request.

This PR improves the overall user experience by adding a `<form>` element to the template and also making sure only one button is of type `submit`, thus allowing the user to submit a request by pressing ENTER when any input element has focus.
