### PR TITLE
fix the selected index disappearing from the select box

### DIFF
--- a/partials/analysis.html
+++ b/partials/analysis.html
@@ -17,6 +17,7 @@
                   <div class="form-group">
                     <label class="form-label">index name</label>
                     <select class="form-control input-sm" ng-model="field_index" ng-options="i as i.name for i in indices">
+                      <option value="">{{ field_index.name }}</option>
                     </select>
                   </div>
                 </div>


### PR DESCRIPTION
The reason this was happening was that whenever the indices variable was
updated the whole select and ng-options values were updated and for some
reason when that happened it ignores the model you have selected. So if
you had a 3s autorefresh it would take 3s to disappear, or 5s or 1min...
The way this fix works is by adding a default value to the ng-options.

Really this is just a visual fix because the ng-model field_index was never
actually reset, you could still select from the other sub-menus.

However, maybe a better approach would be not to auto-refresh the index list
and instead provide a button to carry out that action explicitly because
auto-updating also causes some trouble when you have many indices and you
select form the list since it keeps auto-updating it brings you to the top every 3s
(or whatever your interval is)
