### PR TITLE
Adding ability to externally manage the default host

### DIFF
--- a/kopf_external_settings.json
+++ b/kopf_external_settings.json
@@ -2,5 +2,6 @@
     "elasticsearch_root_path": "",
     "with_credentials": false,
     "theme": "dark",
-    "refresh_rate": 5000
+    "refresh_rate": 5000,
+    "default_host": ""
 }

--- a/src/kopf/controllers/global.js
+++ b/src/kopf/controllers/global.js
@@ -19,7 +19,7 @@ kopf.controller('GlobalController', ['$scope', '$location', '$sce', '$window',
 
     $scope.connect = function() {
       try {
-        var host = 'http://localhost:9200'; // default
+        var host = ExternalSettingsService.getDefaultHost(); // default from config if not set in this block
         if ($location.host() !== '') { // not opening from fs
           var location = $scope.readParameter('location');
           var url = $location.absUrl();
@@ -27,7 +27,7 @@ kopf.controller('GlobalController', ['$scope', '$location', '$sce', '$window',
             host = location;
           } else if (url.indexOf('/_plugin/kopf') > -1) {
             host = url.substring(0, url.indexOf('/_plugin/kopf'));
-          } else {
+          } else if (!host){
             host = $location.protocol() + '://' + $location.host() +
                 ':' + $location.port();
           }

--- a/src/kopf/services/external_settings.js
+++ b/src/kopf/services/external_settings.js
@@ -1,5 +1,7 @@
 kopf.factory('ExternalSettingsService', function($http, $q) {
 
+  var DEFAULT_HOST = 'default_host';
+  
   var ES_ROOT_PATH = 'elasticsearch_root_path';
 
   var WITH_CREDENTIALS = 'with_credentials';
@@ -41,6 +43,10 @@ kopf.factory('ExternalSettingsService', function($http, $q) {
       });
     }
     return this.settings;
+  };
+
+  this.getDefaultHost = function() {
+    return this.getSettings()[DEFAULT_HOST];
   };
 
   this.getElasticsearchRootPath = function() {


### PR DESCRIPTION
This doesn't solve an issue that anyone has raised, but although I wasn't smart enough to do the other request I asked for I saw this simple (OK so it took me an hour!) one that I thought might help people and I've already implemented it myself on our cluster.

For your consideration :)