### PR TITLE
Updating Docker container KOPF version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install envtpl
 ADD nginx.conf.tpl /etc/nginx/nginx.conf.tpl
 
 # kopf
-ENV KOPF_VERSION 1.4.4
+ENV KOPF_VERSION 1.5.5
 RUN curl -s -L "https://github.com/lmenezes/elasticsearch-kopf/archive/v${KOPF_VERSION}.tar.gz" | \
     tar xz -C /tmp && mv "/tmp/elasticsearch-kopf-${KOPF_VERSION}" /kopf
 


### PR DESCRIPTION
Updated KOPF version used in the Dockerfile and built with Docker. Tested in production and it works well.