### PR TITLE
Updated tooltip for "indices.cache.filter.size"

### DIFF
--- a/partials/cluster_settings/cluster.html
+++ b/partials/cluster_settings/cluster.html
@@ -11,7 +11,7 @@
 	<div class="col-md-4 col-sm-6 col-xs-12">
 		<div class="form-group">
 			<label class="form-label">indices.cache.filter.size</label>
-			<span class="setting-info" data-toggle="tooltip" data-placement="bottom" title="The setting that allows one to control the memory size for the filter cache is indices.cache.filter.size, which defaults to 20%. Note, this is not an index level setting but a node level setting (can be configured in the node configuration).">
+			<span class="setting-info" data-toggle="tooltip" data-placement="bottom" title="The setting that allows one to control the memory size for the filter cache is indices.cache.filter.size, which defaults to 10%. Note, this is not an index level setting but a node level setting (can be configured in the node configuration).">
 				<i class="fa fa-info-circle"></i>
 			</span>
 			<input type="text" class="form-control input-sm" ng-model="settings[active_settings]['indices.cache.filter.size']" placeholder=""/>


### PR DESCRIPTION
The tooltip for "indices.cache.filter.size" incorrectly says the default is 20%, the default is 10% and is referenced here - 

https://www.elastic.co/guide/en/elasticsearch/reference/1.7/index-modules-cache.html