### PR TITLE
use kopf as the kopf plugin name

### DIFF
--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -1,3 +1,4 @@
 description=kopf - simple web administration tool for Elasticsearch
 version=1.5.7
 site=true
+name=kopf


### PR DESCRIPTION
Due to recent changes in elasticsearch 2.0, you should now set `name` to `kopf` otherwise, elasticsearch-kopf plugin will be installed as `elasticsearch-kopf` instead of `kopf`.

You could also rename your repository if you want to be able to use the simple installation form:

```sh
bin/plugin lmenezes/kopf
```

Hope this helps