### PR TITLE
Docker updates

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,23 +1,22 @@
-FROM ubuntu:14.04
+FROM nginx:1.9.4
 
 # upgrade
-RUN apt-get update
-RUN apt-get upgrade -y
-
-# needed packages
-RUN apt-get install -y --no-install-recommends python-pip curl nginx-core
-RUN pip install envtpl
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends python-pip curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install envtpl
 
 # nginx
 ADD nginx.conf.tpl /etc/nginx/nginx.conf.tpl
+
+# run script
+ADD ./run.sh ./run.sh
 
 # kopf
 ENV KOPF_VERSION 1.5.7
 RUN curl -s -L "https://github.com/lmenezes/elasticsearch-kopf/archive/v${KOPF_VERSION}.tar.gz" | \
     tar xz -C /tmp && mv "/tmp/elasticsearch-kopf-${KOPF_VERSION}" /kopf
-
-# run script
-ADD ./run.sh ./run.sh
 
 # logs
 VOLUME ["/var/log/nginx"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,6 +22,9 @@ if you don't want to get hacked.
 * `KOPF_BASIC_AUTH_LOGIN` basic auth login, if needed
 * `KOPF_BASIC_AUTH_PASSWORD` hashed basic auth password, if needed
 * `KOPF_NGINX_INCLUDE_FILE` file to include into main server of nginx (place allowed ips here)
+* `KOPF_WITH_CREDENTIALS` set the external setting with_credentials. Default: false
+* `KOPF_THEME` set the theme in external settings. Default: dark
+* `KOPF_REFRESH_RATE` set the external setting refresh_rate. Default: 5000
 
 ### Example
 

--- a/docker/nginx.conf.tpl
+++ b/docker/nginx.conf.tpl
@@ -17,8 +17,8 @@ http {
   include /etc/nginx/mime.types;
   default_type application/octet-stream;
 
-  access_log /var/log/nginx/access.log;
-  error_log /var/log/nginx/error.log;
+  access_log /dev/stdout;
+  error_log /dev/stderr;
 
   upstream es {
     {% for server in KOPF_ES_SERVERS.split(",") %}
@@ -65,7 +65,7 @@ http {
     expires -1;
 
     location / {
-      root /kopf;
+      root /kopf/_site;
     }
 
     location /es/ {

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -8,6 +8,17 @@ if [ ! -z "${KOPF_BASIC_AUTH_LOGIN}" ]; then
     echo "${KOPF_BASIC_AUTH_LOGIN}:${KOPF_BASIC_AUTH_PASSWORD}" > /etc/nginx/kopf.htpasswd
 fi
 
-echo '{"elasticsearch_root_path": "/es"}' > /kopf/kopf_external_settings.json
+KOPF_REFRESH_RATE="${KOPF_REFRESH_RATE:-5000}"
+KOPF_THEME="${KOPF_THEME:-dark}"
+KOPF_WITH_CREDENTIALS="${KOPF_WITH_CREDENTIALS:-false}"
+
+cat <<EOF > /kopf/_site/kopf_external_settings.json
+{
+    "elasticsearch_root_path": "/es",
+    "with_credentials": ${KOPF_WITH_CREDENTIALS},
+    "theme": "${KOPF_THEME}",
+    "refresh_rate": ${KOPF_REFRESH_RATE}
+}
+EOF
 
 exec nginx


### PR DESCRIPTION
Hello,

 I had some trouble getting the current image to run out of the box. Here are the changes I needed to make in order to be able to hit the IP and have Kopf load. With the document root set to /kopf it could not find the index page. I think elasticsearch as a plugin will automatically serve up from the _site directory, and Nginx is unaware. Another alternative is to have the user visit http://<server>/_site but that seemed unfriendly. 

I also refactored the Dockerfile(I couldn't help myself =D) a bit to use the upstream NGINX container and some small refactoring around the RUN commands. The resulting image is ~181MB vs the Ubuntu based  271MB. Also as a result the logs are pushed to stdout/stderr, which makes the docker logs command usable. 

If you want all, some or none of these changes let me know. I can adjust accordingly.

I'm a big fan of the Kopf tool, thanks for all the work you have put into this.