### PR TITLE
need to point to _site directory not root directory when running

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ open http://localhost:9200/_plugin/kopf
 git clone git://github.com/lmenezes/elasticsearch-kopf.git
 cd elasticsearch-kopf
 git checkout {branch|version}
-open index.html
+open _site/index.html
 ```
 
 ps: local execution doesn't work with Chrome(and maybe other browsers). See more [here](http://docs.angularjs.org/api/ng.directive:ngInclude).

--- a/docker/nginx.conf.tpl
+++ b/docker/nginx.conf.tpl
@@ -65,7 +65,7 @@ http {
     expires -1;
 
     location / {
-      root /kopf;
+      root /kopf/_site;
     }
 
     location /es/ {


### PR DESCRIPTION
There is no index.html in the root of the project. There is an index.html in _site though. Updates readme and Dockerfile.

When running the current docker image, you get a 403 Forbidden when trying to hit the container.