### PR TITLE
Make it so container can restart

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-envtpl /etc/nginx/nginx.conf.tpl
+envtpl --keep-template /etc/nginx/nginx.conf.tpl
 
 if [ ! -z "${KOPF_BASIC_AUTH_LOGIN}" ]; then
     echo "${KOPF_BASIC_AUTH_LOGIN}:${KOPF_BASIC_AUTH_PASSWORD}" > /etc/nginx/kopf.htpasswd


### PR DESCRIPTION
Adding this flag to envtpl so the container can be restarted. The default behavior of envtpl is to delete the template file causing a an error on container restart that the nginx.conf.tpl file can not be found. The `--keep-template` flag keeps the template around so the run.sh script can recreate it on restart.
