### PR TITLE
Fixed node cpu stats …

### DIFF
--- a/_site/dist/kopf.js
+++ b/_site/dist/kopf.js
@@ -3117,7 +3117,7 @@ function Node(nodeId, nodeStats, nodeInfo) {
   var usedRatio = (diskUsedInBytes / this.disk_total_in_bytes);
   this.disk_used_percent = Math.round(100 * usedRatio);
 
-  this.cpu = getProperty(this.stats, 'process.cpu.percent');
+  this.cpu = Math.round(getProperty(this.stats, 'process.cpu.percent') / getProperty(nodeInfo, 'os.cpu.total_cores'));
 
   this.load_average = getProperty(this.stats, 'os.load_average');
 


### PR DESCRIPTION
…so that the percentage value is divided by the number of reported cores, since elasticsearch is reporting summarized stats across all (HT-)cores.