### PR TITLE
fix(rest/encodeUrlPath): EncodeURI the req path to escape special characters

### DIFF
--- a/_site/dist/kopf.js
+++ b/_site/dist/kopf.js
@@ -1790,7 +1790,7 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
     $scope.copyAsCURLCommand = function() {
       var method = $scope.request.method;
       var host = ElasticService.getHost();
-      var path = $scope.request.path;
+      var path = encodeURI($scope.request.path);
       var body = $scope.editor.getValue();
       var curl = 'curl -X' + method + ' \'' + host + path + '\'';
       if (['POST', 'PUT'].indexOf(method) >= 0) {
@@ -1823,7 +1823,7 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
     };
 
     $scope.loadFromHistory = function(request) {
-      $scope.request.path = request.path;
+      $scope.request.path = encodeURI(request.path);
       $scope.request.body = request.body;
       $scope.request.method = request.method;
       $scope.editor.setValue(request.body);
@@ -1849,6 +1849,7 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
 
     $scope.sendRequest = function() {
       if (notEmpty($scope.request.path)) {
+        var path = encodeURI($scope.request.path);
         $scope.request.body = $scope.editor.format();
         $('#rest-client-response').html('');
         if ($scope.request.method == 'GET' && '{}' !== $scope.request.body) {
@@ -1856,7 +1857,7 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
               'content. Maybe you meant to use POST or PUT?');
         }
         ElasticService.clusterRequest($scope.request.method,
-            $scope.request.path, {}, $scope.request.body,
+            path, {}, $scope.request.body,
             function(response) {
               var content = response;
               try {
@@ -1865,7 +1866,7 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
                 // nothing to do
               }
               $('#rest-client-response').html(content);
-              $scope.addToHistory(new Request($scope.request.path,
+              $scope.addToHistory(new Request(path,
                   $scope.request.method, $scope.request.body));
             },
             function(error, status) {
@@ -1877,7 +1878,7 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
                   $('#rest-client-response').html(error);
                 }
               } else {
-                var url = ElasticService.connection.host + $scope.request.path;
+                var url = ElasticService.connection.host + path;
                 AlertService.error(url + ' is unreachable');
               }
             }
@@ -5380,8 +5381,7 @@ kopf.factory('PageService', ['ElasticService', 'DebugService', '$rootScope',
       if (name !== this.clusterName) {
         if (name) {
           $rootScope.title = 'kopf[' + name + ']';
-        }
-        else {
+        } else {
           $rootScope.title = 'kopf - no connection';
         }
         this.clusterName = name;

--- a/src/kopf/controllers/rest.js
+++ b/src/kopf/controllers/rest.js
@@ -14,7 +14,7 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
     $scope.copyAsCURLCommand = function() {
       var method = $scope.request.method;
       var host = ElasticService.getHost();
-      var path = $scope.request.path;
+      var path = encodeURI($scope.request.path);
       var body = $scope.editor.getValue();
       var curl = 'curl -X' + method + ' \'' + host + path + '\'';
       if (['POST', 'PUT'].indexOf(method) >= 0) {
@@ -47,7 +47,7 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
     };
 
     $scope.loadFromHistory = function(request) {
-      $scope.request.path = request.path;
+      $scope.request.path = encodeURI(request.path);
       $scope.request.body = request.body;
       $scope.request.method = request.method;
       $scope.editor.setValue(request.body);
@@ -73,6 +73,7 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
 
     $scope.sendRequest = function() {
       if (notEmpty($scope.request.path)) {
+        var path = encodeURI($scope.request.path);
         $scope.request.body = $scope.editor.format();
         $('#rest-client-response').html('');
         if ($scope.request.method == 'GET' && '{}' !== $scope.request.body) {
@@ -80,7 +81,7 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
               'content. Maybe you meant to use POST or PUT?');
         }
         ElasticService.clusterRequest($scope.request.method,
-            $scope.request.path, {}, $scope.request.body,
+            path, {}, $scope.request.body,
             function(response) {
               var content = response;
               try {
@@ -89,7 +90,7 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
                 // nothing to do
               }
               $('#rest-client-response').html(content);
-              $scope.addToHistory(new Request($scope.request.path,
+              $scope.addToHistory(new Request(path,
                   $scope.request.method, $scope.request.body));
             },
             function(error, status) {
@@ -101,7 +102,7 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
                   $('#rest-client-response').html(error);
                 }
               } else {
-                var url = ElasticService.connection.host + $scope.request.path;
+                var url = ElasticService.connection.host + path;
                 AlertService.error(url + ' is unreachable');
               }
             }

--- a/src/kopf/services/page.js
+++ b/src/kopf/services/page.js
@@ -33,8 +33,7 @@ kopf.factory('PageService', ['ElasticService', 'DebugService', '$rootScope',
       if (name !== this.clusterName) {
         if (name) {
           $rootScope.title = 'kopf[' + name + ']';
-        }
-        else {
+        } else {
           $rootScope.title = 'kopf - no connection';
         }
         this.clusterName = name;


### PR DESCRIPTION
Heya folks.

I'm trying to search the ES index to get data and it makes me sad that the `$scope.request.path` isnt escaped properly.

I'm trying to get data out as a CSV and since this feature doesn't land in Kibana for a while, the best bet is to use our kopf dashboard to hack around that limitation.
Real example: We're running a query like so:  
`/_search?q=remote_services.proccess:%20nginx%20AND%20team:%20RackspaceMonitoring`
Isn't this so much more human readable?  
`/_search?q=remote_services.proccess: nginx AND team: RackspaceMonitoring`
And that way I dont need to know what the escaped character codes for things are! 