### PR TITLE
Fix bug with cURL copy to clipboard when rest URL is missing leading slash

### DIFF
--- a/src/kopf/controllers/rest.js
+++ b/src/kopf/controllers/rest.js
@@ -27,6 +27,9 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
       var method = $scope.request.method;
       var host = ElasticService.getHost();
       var path = encodeURI($scope.request.path);
+	  if(path.substring(0,1) !== '/') {
+		  path = '/' + path;
+	  }
       var body = $scope.editor.getValue();
       var curl = 'curl -X' + method + ' \'' + host + path + '\'';
       if (['POST', 'PUT'].indexOf(method) >= 0) {


### PR DESCRIPTION
Let me know if you have a contributer's agreement or anything you need me to complete, or if you'd like me to create an issue to pair this up with, etc. Thanks.