### PR TITLE
Fixes HTTP 301 when access elasticsearch root URL

### DIFF
--- a/_site/dist/kopf.js
+++ b/_site/dist/kopf.js
@@ -5319,7 +5319,7 @@ kopf.factory('ElasticService', ['$http', '$q', '$timeout', '$location',
         $http.get(host + '/_aliases', params),
         $http.get(host + '/_cluster/health', params),
         $http.get(host + '/_nodes/_all/os,jvm', params),
-        $http.get(host, params),
+        $http.get(host + '/', params),
       ]).then(
           function(responses) {
             try {

--- a/src/kopf/services/elastic.js
+++ b/src/kopf/services/elastic.js
@@ -786,7 +786,7 @@ kopf.factory('ElasticService', ['$http', '$q', '$timeout', '$location',
         $http.get(host + '/_aliases', params),
         $http.get(host + '/_cluster/health', params),
         $http.get(host + '/_nodes/_all/os,jvm', params),
-        $http.get(host, params),
+        $http.get(host + '/', params),
       ]).then(
           function(responses) {
             try {


### PR DESCRIPTION
Hello there,

I got some trouble when tried to deploy the docker image behind a load balancer
with SSL termination.

When the client sends a request to `elasticsearch_root_path ` (for example `/es`), 
the nginx server used in the docker image would send a HTTP 301 redirect to `/es/`.

According to the Nginx documentation:

> If a location is defined by a prefix string that ends with the slash character, and 
> requests are processed by one of proxy_pass, fastcgi_pass, uwsgi_pass, scgi_pass,
> or memcached_pass, then the special processing is performed. In response to a
> request with URI equal to this string, but without the trailing slash, a permanent 
> redirect with the code 301 will be returned to the requested URI with the slash
> appended. 

Normally, that's not a big deal. But it may cause problems when it's deployed behind 
some load balancers with SSL termination enabled. If these load balancers does not
set `X-Forwarded-Proto` header properly, the scheme part of redirection url would be
http instead of https. When the client try to send requests to the new url, it would be
blocked by the browser for the sake of security.

It's an edge case though.

Regards,
Kent