### PR TITLE
Allow specifying default elasticsearch host in kopf_external_settings

### DIFF
--- a/src/kopf/controllers/global.js
+++ b/src/kopf/controllers/global.js
@@ -41,7 +41,8 @@ kopf.controller('GlobalController', ['$scope', '$location', '$sce', '$window',
         if ($location.host() !== '') { // not opening from fs
           var location = $scope.readParameter('location');
           var url = $location.absUrl();
-          if (isDefined(location)) {
+          if (isDefined(location) ||
+              isDefined(location = ExternalSettingsService.getElasticsearchHost())) {
             host = location;
           } else if (url.indexOf('/_plugin/kopf') > -1) {
             host = url.substring(0, url.indexOf('/_plugin/kopf'));

--- a/src/kopf/services/external_settings.js
+++ b/src/kopf/services/external_settings.js
@@ -3,6 +3,8 @@ kopf.factory('ExternalSettingsService', ['DebugService',
 
     var KEY = 'kopfSettings';
 
+    var ES_HOST = 'location';
+
     var ES_ROOT_PATH = 'elasticsearch_root_path';
 
     var WITH_CREDENTIALS = 'with_credentials';
@@ -52,6 +54,10 @@ kopf.factory('ExternalSettingsService', ['DebugService',
         };
       });
       return settings;
+    };
+
+    this.getElasticsearchHost = function() {
+      return this.getSettings()[ES_HOST];
     };
 
     this.getElasticsearchRootPath = function() {


### PR DESCRIPTION
Only applies if `location` key is present in kopf_external_settings.json file, otherwise uses existing heuristics to determine default host.