### PR TITLE
Update tabs to spaces

### DIFF
--- a/src/kopf/controllers/rest.js
+++ b/src/kopf/controllers/rest.js
@@ -31,9 +31,9 @@ kopf.controller('RestController', ['$scope', '$location', '$timeout',
       var method = $scope.request.method;
       var host = ElasticService.getHost();
       var path = encodeURI($scope.request.path);
-	  if(path.substring(0,1) !== '/') {
-		  path = '/' + path;
-	  }
+      if(path.substring(0,1) !== '/') { 
+        path = '/' + path;
+      }
       var body = $scope.editor.getValue();
       var curl = 'curl -X' + method + ' \'' + host + path + '\'';
       if (['POST', 'PUT'].indexOf(method) >= 0) {


### PR DESCRIPTION
user@user:~/elasticsearch-kopf$ grunt server
(node:22909) DeprecationWarning: process.EventEmitter is deprecated. Use require('events') instead.
Running "clean:dist" (clean) task

Running "jshint:kopf" (jshint) task
Linting src/kopf/controllers/rest.js ...ERROR
[L34:C1] W099: Mixed spaces and tabs.
    if(path.substring(0,1) !== '/') {
[L35:C2] W099: Mixed spaces and tabs.
      path = '/' + path;
[L36:C1] W099: Mixed spaces and tabs.
    }

Warning: Task "jshint:kopf" failed. Use --force to continue.

Aborted due to warnings.
user@user:~/elasticsearch-kopf$ grunt --version
grunt-cli v1.2.0
grunt v0.4.5
user@user:~/elasticsearch-kopf$ node --version
v6.5.0
user@user:~/elasticsearch-kopf$ npm --version
3.10.3