### PR TITLE
Use PUT to create indices, not POST

### DIFF
--- a/_site/dist/kopf.js
+++ b/_site/dist/kopf.js
@@ -4701,7 +4701,7 @@ kopf.factory('ElasticService', ['$http', '$q', '$timeout', '$location',
      */
     this.createIndex = function(name, settings, success, error) {
       var path = '/' + encode(name);
-      this.clusterRequest('POST', path, {}, settings, success, error);
+      this.clusterRequest('PUT', path, {}, settings, success, error);
     };
 
     /**

--- a/src/kopf/services/elastic.js
+++ b/src/kopf/services/elastic.js
@@ -168,7 +168,7 @@ kopf.factory('ElasticService', ['$http', '$q', '$timeout', '$location',
      */
     this.createIndex = function(name, settings, success, error) {
       var path = '/' + encode(name);
-      this.clusterRequest('POST', path, {}, settings, success, error);
+      this.clusterRequest('PUT', path, {}, settings, success, error);
     };
 
     /**


### PR DESCRIPTION
Documentation for 2.x and 5.x defines PUT as operation to create an index. Starting with 5.0.0-rc1 POST is not allowed for creating indices anymore.