### PR TITLE
Fix headings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ Installation
 ------------
 You can either install a specific version(using its release tag) or the most up to date version from a given branch.
 
-####Installing on an Elasticsearch instance:
+#### Installing on an Elasticsearch instance:
 
 ```bash
 ./elasticsearch/bin/plugin install lmenezes/elasticsearch-kopf/{branch|version}
 open http://localhost:9200/_plugin/kopf
 ```
 
-####Run locally:
+#### Run locally:
 
 ```bash
 git clone git://github.com/lmenezes/elasticsearch-kopf.git
@@ -52,7 +52,7 @@ grunt server
 
 Browse to <http://localhost:9000/_site>.
 
-####Kopf behind a reverse proxy
+#### Kopf behind a reverse proxy
 Example configuration for nginx:
 ```
 server {
@@ -80,12 +80,12 @@ Example configuration for kopf(kopf_external_settings.json):
 }
 ```
 Access kopf at http://localhost:8080/kopf/
-####Try it online:
+#### Try it online:
 ```
 http://lmenezes.com/elasticsearch-kopf/?location=http://localhost:9200
 ```
 
-####Basic HTTP Auth support:
+#### Basic HTTP Auth support:
 ```
 http://lmenezes.com/elasticsearch-kopf/?location=http://user:pwd@localhost:9200
 ```
@@ -98,26 +98,26 @@ The plugin modifies the base elasticsearch response and therefore this workaroun
 
 Screenshots
 ------------
-####cluster overview
+#### cluster overview
 ![cluster overview](imgs/cluster_view.png)
 
-####header reflects cluster state
+#### header reflects cluster state
 ![cluster state](imgs/cluster_state.png)
 
-####REST Client
+#### REST Client
 ![rest client](imgs/rest_client.png)
 
-####aliases management
+#### aliases management
 ![aliases management](imgs/aliases.png)
 
-####warmers management
+#### warmers management
 ![warmers management](imgs/warmer.png)
 
-####percolator
+#### percolator
 ![percolator](imgs/percolator.png)
 
-####snapshots management
+#### snapshots management
 ![snapshots management](imgs/snapshot.png)
 
-####analysis api
+#### analysis api
 ![analysis api](imgs/analysis.png)


### PR DESCRIPTION
GitHub changed the way markdown renders to html.
This fixes the headings in the README.